### PR TITLE
add an update check to the wrapper script

### DIFF
--- a/rax-docs
+++ b/rax-docs
@@ -100,6 +100,43 @@ function tools_check {
     }
 }
 
+function update_check {
+    mkdir -p .rax-docs/cache
+    [ -d .rax-docs/repo ] || return 0
+    # All timestamps are gotten in seconds since epoch
+    LAST_CHECK=$(stat -c %Y .rax-docs/cache/update_check 2>&1) || {
+	# If there's no record of a check, it was probably just installed, so assume it's up
+	# to date. This will also help prevent the update check from interfering with tests.
+	LAST_CHECK=$(date +%s)
+    }
+    # Regardless of the outcome, only let this happen once per check period. If it fails because
+    # github connections are timing out, doing it over and over until we succeed would make the
+    # toolkit useless.
+    touch .rax-docs/cache/update_check
+    # Check for updates if not fetched the previous week
+    NEXT_CHECK=$((LAST_CHECK + 604800))
+    NOW=$(date +%s)
+    if [ "$NOW" -gt "$NEXT_CHECK" ]; then
+	git -C .rax-docs/repo fetch --prune --tags &> /dev/null || true
+	MY_TS=$(stat -c %Y "$SCRIPTNAME")
+	THEIR_TS_GIT=$(git -C .rax-docs/repo log -1 --pretty="format:%ci" origin/master -- rax-docs)
+	THEIR_TS=$(date -d "$THEIR_TS_GIT" +%s)
+	if [ "$MY_TS" -lt "$THEIR_TS" ]; then
+	    echo "A new version of this script is available!"
+	    echo ""
+	    echo "It may have bugfixes or new features available. You should"
+	    echo "consider trying it out by grabbing it from"
+	    echo "https://github.rackspace.com/dcx/rax-docs"
+	    echo ""
+	    read -rp "Press the any key to continue " -n1
+	    [ "$REPLY" = "" ] || echo ""
+	    echo ""
+	fi
+    fi
+}
+
+update_check
+
 [ $# -eq 0 ] && {
     echo "Try '$SCRIPTNAME install' to install the toolkit."
     echo "For additional information, see the readme at"

--- a/tests/install-fixtures/git
+++ b/tests/install-fixtures/git
@@ -1,12 +1,24 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Stubs out git for tests. This way we can verify the right commands are
 # being run without actually cloning or changing versions. Writing tests
 # otherwise is tricky because you're testing the cloned toolkit instead
 # of the local one.
 echo "$@" >> git-input
+
+# After a clone, the wrapper expects to be able to call the main
+# internal script, so put that test fixture in place.
 [ "$1" = clone ] && {
   mkdir -p .rax-docs/repo/internal
   mv main .rax-docs/repo/internal
+}
+
+# The update check uses git log to compare timestamps, so this command
+# has to produce a timestamp as output, formatted like git does. The
+# format looks like "2021-02-26 14:22:38 -0600". Just output the
+# current time to trigger the update logic.
+UPDATE_LOG_CMD='log -1 --pretty='
+[[ "$*" =~ $UPDATE_LOG_CMD ]] && {
+    date +"%Y-%m-%d %H:%M:%S %z"
 }
 exit 0

--- a/tests/main-install.bats
+++ b/tests/main-install.bats
@@ -141,7 +141,7 @@ Clone url : git url"
 @test "installing latest pins to a specific version" {
     run .rax-docs/repo/internal/main internal_install <<<"$ALL_YES"
     [ "$status" -eq 0 ]
-    [[ "${lines[7]}" =~ Version:\ (.*) ]]
+    [[ "${lines[6]}" =~ Version:\ (.*) ]]
     REPORTED_VERSION="${BASH_REMATCH[1]}"
     ACTUAL_VERSION=$(git -C .rax-docs/repo rev-parse HEAD)
     SAVED_VERSION=$(grep 'TOOLKIT_VERSION="' .rax-docs/config/bash)


### PR DESCRIPTION
In order to encourage users to keep up to date, this adds an update
check to the wrapper script to let them know if a new version of that
script is available.

Update checks for internal files can be handled internally.

Also fixes a test that somehow got committed failing because of
changes to the output a while back.