### PR TITLE
add first integration test

### DIFF
--- a/.github/workflows/first-action.yml
+++ b/.github/workflows/first-action.yml
@@ -34,8 +34,10 @@ jobs:
         run: |
           shellcheck rax-docs
           find internal -type f | xargs shellcheck
-          find tests -type f | xargs shellcheck
+          find tests -type f -not -name README.md | xargs shellcheck
+          find it -type f -not -name README.md | xargs shellcheck
 
       - name: Run tests
         run: |
           bats tests
+          bats it

--- a/README.md
+++ b/README.md
@@ -191,3 +191,11 @@ testing.
 `SPEED`: By default, there are some pauses during output for human
 readability. Tests shouldn't need to wait for these pauses, so set this to
 `true` for faster results.
+
+`NO_DOCKER_BUILD`: The Docker integration tests exercise building the
+Docker image for the dev environment. That's a really slow process
+that also clobbers your local docs image. Set this variable to any
+value to skip tests that build a new image.
+
+See the `tests` and `it` directories for further details on the unit
+and integration tests, respectively.

--- a/internal/main
+++ b/internal/main
@@ -347,6 +347,14 @@ function inspect_old_jenkinsfile {
     }
 }
 
+# Sets up the tools environment, either in Jenkins or for a dev.
+function setup {
+    echo "Setting up local dev environment"
+    echo ""
+    docker rmi rax-docs:latest > /dev/null 2>&1 || true
+    docker build .rax-docs/repo/resources -t rax-docs
+}
+
 function usage {
     cat <<EOF
 Usage: rax-docs <command> [command-options]
@@ -443,7 +451,7 @@ TOPCMD="$1"
 shift
 
 case $TOPCMD in
-    internal_install|status|usage)
+    internal_install|status|usage|setup)
 	$TOPCMD "$@"
 	;;
 

--- a/it/README.md
+++ b/it/README.md
@@ -1,0 +1,24 @@
+Integration tests
+=================
+
+This directory contains integration tests of the project. Integration
+tests should:
+
+- Cover the gaps that unit tests can't cover
+
+- Ensure that the individual units, tested separately by unit tests,
+  work together
+
+- Be as quick as possible, but be allowed to take time to test things
+  that can't be tested in a fast unit test
+
+- Be easy to read, just like a unit test
+
+You can run all integration tests by running
+
+    bats it
+
+in the project root directory.
+
+All integration test files end with the `.bats` extension and live in
+this directory. Bats doesn't handle recursive test directories.

--- a/it/docker-image.bats
+++ b/it/docker-image.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# -*- mode: sh -*-
+
+## Integration (slow and destructive) tests of the Docker
+## container. Your local image WILL BE OVERWRITTEN when you run these
+## tests.
+##
+## Set the env var NO_DOCKER_BUILD to any value to prevent building a
+## new image, but realize that the remaining tests will then run with
+## your current image, which may not behave as the tests expect.
+
+function setup {
+    # Run each test in an isolated, clean working directory
+    TMPDIR=$(mktemp -d)
+    # The project has the local version of the toolkit in it
+    cp rax-docs "$TMPDIR"
+    mkdir -p "$TMPDIR"/.rax-docs
+    cp -r ./ "$TMPDIR"/.rax-docs/repo/
+    cd "$TMPDIR" || exit 1
+}
+
+function teardown {
+    # On failure, you almost always need the output to figure out what went wrong
+    echo "--- output"
+    echo "$output"
+    rm -rf "$TMPDIR"
+}
+
+@test "setup produces a docker image" {
+    [ -n "$NO_DOCKER_BUILD" ] && skip "User requested skipping docker image build"
+    # Delete any existing image so we see if it really builds one
+    docker rmi rax-docs || true
+    run ./rax-docs setup
+    [ "$status" -eq 0 ]
+    docker image inspect rax-docs:latest
+}
+
+## If the above test fails, the image won't have been built, and
+## everything following will also fail.
+
+@test "the image has python installed" {
+    run docker run --rm rax-docs python --version
+    # This is the python version matching Jenkins
+    [ "$output" = "Python 2.7.13" ]
+}
+
+@test "the image has a pip that works with python 2" {
+    run docker run --rm rax-docs pip --version
+    # As long as we're in Python 2, pip should be less than version 21
+    [[ "$output" =~ ^pip\ 20\. ]]
+}
+
+@test "the image has sphinx installed" {
+    run docker run --rm rax-docs sphinx-build --version
+    [ "$output" = "Sphinx (sphinx-build) 1.5.6" ]
+}
+
+@test "the image has vale installed" {
+    run docker run --rm rax-docs vale --version
+    [ "$output" = "vale version 2.4.0" ]
+}

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:2.7.13
+
+COPY requirements.txt requirements.txt
+
+RUN mkdir /root/.ssh && \
+  chmod 0600 /root/.ssh && \
+  ln -s /ssh_config/id_rsa /root/.ssh/id_rsa && \
+  ln -s /ssh_config/id_rsa.pub /root/.ssh/id_rsa.pub && \
+  ln -s /ssh_config/known_hosts /root/.ssh/known_hosts
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  curl \
+  enchant \
+  libbz2-dev \
+  libncurses5-dev \
+  libncursesw5-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  llvm \
+  make \
+  tk-dev \
+  wget \
+  xz-utils \
+  zlib1g-dev
+
+RUN pip install --upgrade pip\<21
+RUN pip install -r requirements.txt
+
+run wget https://install.goreleaser.com/github.com/ValeLint/vale.sh && \
+    sh vale.sh -b /usr/local/bin v2.4.0 && \
+    mkdir -p styles/Vocab && \
+    git clone https://github.com/achatur/docs-vale.git styles/docs-vale && \
+    git clone https://github.com/errata-ai/Google.git styles/Google && \
+    git clone https://github.com/errata-ai/Microsoft.git styles/Microsoft
+
+ENV NO_VENV true

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,0 +1,47 @@
+# These requirements are copied in from the legacy toolkit. I have no
+# idea why most of these modules are required. Some are obvious, like
+# sphinx and doc8.
+
+-i https://pypi.python.org/simple
+alabaster==0.7.12
+babel==2.6.0
+certifi==2018.10.15
+chardet==3.0.4
+chios==0.1.4
+click==7.0
+colorclass==2.2.0
+commonmark==0.5.4
+doc8==0.8.0
+docutils==0.14
+filelock==3.0.9
+idna==2.7
+imagesize==1.1.0
+jinja2==2.10
+markdown==3.0.1
+markupsafe==1.1.1
+packaging==18.0
+pandoc==1.0.2
+pbr==5.1.0
+# Can't go to 21 or later until we move to Python 3
+pip<21
+pluggy==0.8.0
+ply==3.11
+py==1.7.0
+pyenchant==2.0.0
+pygments==2.2.0
+pyparsing==2.2.2
+pytz==2018.7
+recommonmark==0.4.0
+requests==2.20.0
+restructuredtext-lint==1.1.3
+six==1.11.0
+snowballstemmer==1.2.1
+sphinx-rtd-theme==0.4.2
+sphinx==1.5.6
+sphinxcontrib-spelling==4.2.0
+sphinxcontrib-versioning==2.2.1
+sphinxcontrib-websupport==1.1.0
+stevedore==1.30.0
+toml==0.10.0
+urllib3==1.24
+virtualenv==16.0.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,35 @@
+Unit tests
+==========
+
+This directory contains unit tests of the project. Unit tests should:
+
+- Be fast, so they can run frequently
+
+- Be easy to read, so other people can understand how a feature is
+  supposed to behave
+
+- Catch as many errors as is reasonable, before they make it further
+  along the pipeline and get harder to fix
+
+You can run all unit tests by running
+
+    bats tests
+
+in the project root directory.
+
+Test files
+----------
+
+A unit test file should focus on one feature or group of related
+features that it can easily test with the same setup, teardown and
+test fixture(s). All unit tests files end with the `.bats` extension
+and live in this directory. Bats doesn't handle recursive test
+directories.
+
+Test fixtures
+-------------
+
+Test fixtures are in subdirectories of this directory to keep them
+organized. Typically, a unit test will use a test fixture by copying
+the fixture directory into a temporary working directory for the scope
+of the test.

--- a/tests/project-structure.bats
+++ b/tests/project-structure.bats
@@ -5,26 +5,25 @@
 ## sure tools like bats and shellcheck are finding all the right
 ## files.
 
-@test "tests are in the 'tests' directory" {
+@test "unit tests are in the 'tests' directory" {
     MYDIR="$BATS_TEST_DIRNAME"
     NAME=$(basename "$MYDIR")
     [ "$NAME" = "tests" ]
 }
 
-@test "test files only exist in the test directory" {
+@test "test files only exist in the test directories" {
     TESTDIR="$BATS_TEST_DIRNAME"
     PROJECTDIR=$(dirname "$TESTDIR")
+    ITDIR="$PROJECTDIR"/it
     ALLTESTS=$(find "$PROJECTDIR" -name '*.bats')
     for TEST in $ALLTESTS; do
 	echo "Check test: $TEST"
 	DIR=$(dirname "$TEST")
-	[ "$TESTDIR" = "$DIR" ]
+	[ "$TESTDIR" = "$DIR" ] || [ "$ITDIR" = "$DIR" ]
     done
 }
 
 @test "project root contains the expected files" {
-    # The only files should be the wrapper script and readme. The only
-    # dirs should be tests and internal scripts.
     TESTDIR="$BATS_TEST_DIRNAME"
     PROJECTDIR=$(dirname "$TESTDIR")
     cd "$PROJECTDIR"
@@ -33,6 +32,8 @@
 	[ "$FILE" = "README.md" ] ||
 	    [ "$FILE" = "rax-docs" ] ||
 	    [ "$FILE" = "internal" ] ||
-	    [ "$FILE" = "tests" ]
+	    [ "$FILE" = "resources" ] ||
+	    [ "$FILE" = "tests" ] ||
+	    [ "$FILE" = "it" ]
     done
 }

--- a/tests/wrapper-script.bats
+++ b/tests/wrapper-script.bats
@@ -1,6 +1,11 @@
 #!/usr/bin/env bats
 # -*- mode: sh -*-
 
+## Tests of the wrapper script, isolated from the internals by the
+## test fixture copied in during setup. These tests focus on the
+## behavior of the wrapper script alone by passing values to it and
+## inspecting the commands it runs and values it returns.
+
 function setup {
     # Tell the script not to pause for human readability
     export SPEED=true


### PR DESCRIPTION
As I continue testing, it becomes apparent that it'll be useful to
divide unit (fast) tests from integration (maybe slow) tests. Building
the docker image is one such test. It can take quite a while, and it
also has the side effect of overwriting your local image, so it's not
one you want to include in the "run all the time" test suite.

This adds initial docker image tests as the first integration test.