### PR TITLE
check out version on wrapper install

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -101,9 +101,6 @@ function install_version_set {
 	DISCOVER_VERSION=false
     fi
     echo ""
-    OUTPUT=$(git -C .rax-docs/repo checkout "$CHOSEN_VERSION" 2>&1) || {
-	fail "Error checking out toolkit version:\n\n$OUTPUT"
-    }
     # Don't store a branch as the version. That would lead to non-reproducible builds due to
     # building based on a moving target version.
     git -C .rax-docs/repo show-ref --verify "refs/heads/$CHOSEN_VERSION" &> /dev/null && {

--- a/rax-docs
+++ b/rax-docs
@@ -36,6 +36,16 @@ function install {
         echo "$OUTPUT"
         exit 1
     }
+    VERSION="${1:-master}"
+    OUTPUT=$(git -C .rax-docs/repo checkout "$VERSION" 2>&1) || {
+	echo "Error checking out requested version."
+	echo ""
+	echo "The version you requested ($VERSION) isn't a valid git treeish."
+	echo "You need to specify a tag, branch, or commit hash to install."
+	echo ""
+	echo "$OUTPUT"
+	return 1
+    }
     .rax-docs/repo/internal/main internal_install "$@"
 }
 

--- a/tests/wrapper-script.bats
+++ b/tests/wrapper-script.bats
@@ -46,11 +46,12 @@ function teardown {
     [ $status -eq 1 ]
 }
 
-@test "running install clones the toolkit" {
+@test "running install clones the toolkit and switches versions" {
     run ./rax-docs install some-version <<<"$(printf "y\ny\ny\ny\ny\ny\ny\n")"
     [ "${lines[-1]}" = "install command completed" ]
     [ $status -eq 0 ]
-    [ "$(cat git-input)" = "clone https://github.com/IDPLAT/rax-docs.git .rax-docs/repo" ]
+    [ "$(head -1 git-input)" = "clone https://github.com/IDPLAT/rax-docs.git .rax-docs/repo" ]
+    [ "$(tail -1 git-input)" = "-C .rax-docs/repo checkout some-version" ]
     [ "$(cat main-input)" = "internal_install some-version" ]
 }
 


### PR DESCRIPTION
All this time, the wrapper has been leaving the version checkout up to
the internal script, which means the wrapper checks out master and
runs *that* version of the internal script, which is clearly
wrong. This moves the initial version checkout to the wrapper so things
will work as expected.

The internal script still has lots of other version management things
to do. I think they'll work as expected still.