### PR TITLE
stop duplicate .gitignore lines

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -283,7 +283,7 @@ function install_go {
     }
     IGNORE="# Ignore rax-docs installation. It should be pulled with './rax-docs get' when needed.\n.rax-docs/repo\n"
     IGNORE+="# Ignore rax-docs cache dir, where info specific to the local installation is stored.\n.rax-docs/cache"
-    if [ -f .gitignore ]; then
+    if [ -f .gitignore ] && ! grep '^.rax-docs/repo' .gitignore > /dev/null; then
 	echo -e "\n$IGNORE" >> .gitignore
     else
 	echo -e "$IGNORE" > .gitignore

--- a/tests/main-install.bats
+++ b/tests/main-install.bats
@@ -204,6 +204,7 @@ Clone url : git url"
     [ "$status" -eq 0 ]
     [ -f .gitignore ]
     grep '^.rax-docs/repo$' .gitignore
+    grep '^.rax-docs/cache$' .gitignore
     [ -f Jenkinsfile ]
     JENKINS_CS=$(sha1sum < Jenkinsfile)
     ACTUAL_JENKINS_CS=$(sha1sum < .rax-docs/repo/resources/Jenkinsfile)
@@ -218,6 +219,21 @@ Clone url : git url"
     grep '^stuff already ignored$' .gitignore
     grep '^more stuff$' .gitignore
     grep '^.rax-docs/repo$' .gitignore
+}
+
+@test "doesn't add duplicate lines to .gitignore" {
+    # Given a normal install that adds our gitignore entries
+    run .rax-docs/repo/internal/main internal_install <<<"$ALL_YES"
+    [ "$status" -eq 0 ]
+    [ -f .gitignore ]
+    COUNT=$(grep -c '^.rax-docs/' .gitignore)
+    [ "$COUNT" = 2 ]
+    # When I install a second time
+    run .rax-docs/repo/internal/main internal_install <<<"$ALL_YES"
+    [ "$status" -eq 0 ]
+    # Then the gitignores shouldn't be duplicated
+    COUNT=$(grep -c '^.rax-docs/' .gitignore)
+    [ "$COUNT" = 2 ]
 }
 
 @test "installing over an installation succeeds" {


### PR DESCRIPTION
Installing the toolkit helpfully adds things to the project gitignore
that shouldn't be committed; however it does that every time install
runs, which leads to needless duplication. This adds a simple check so
we won't add the lines of it looks like they're already there.

Closes #22