### PR TITLE
remove unused var from Jenkinsfile

### DIFF
--- a/resources/Jenkinsfile
+++ b/resources/Jenkinsfile
@@ -47,7 +47,7 @@ node {
     if (isPr) {
         stage ('Stage preview HTML') {
             withCredentials([usernameColonPassword(credentialsId: 'SVCwPAT', variable: 'GITHUB_SECRET')]) {
-	        sh 'PR_NUMBER=$numberPR ./rax-docs post_build_preview'
+	        sh './rax-docs post_build_preview'
             }
 	}
     } else {


### PR DESCRIPTION
This variable was left over from when I was getting the toolkit to
post a message back to PRs. The PR_NUMBER var is determined inside the
script. The Jenkinsfile doesn't need to calculate it.