### PR TITLE
change update prompt to auto-update

### DIFF
--- a/rax-docs
+++ b/rax-docs
@@ -134,12 +134,28 @@ function update_check {
 	if [ "$MY_TS" -lt "$THEIR_TS" ]; then
 	    echo "A new version of this script is available!"
 	    echo ""
-	    echo "It may have bugfixes or new features available. You should"
-	    echo "consider trying it out by grabbing it from"
-	    echo "https://github.com/IDPLAT/rax-docs"
+	    echo "It may have bugfixes or new features available."
 	    echo ""
-	    read -rp "Press the any key to continue " -n1
-	    [ "$REPLY" = "" ] || echo ""
+	    read -rp "Update now? [Y/n] "
+	    if [ -z "$REPLY" ] || [[ "$REPLY" =~ ^[Yy].* ]]; then
+		# Download to a temp location and then switch files
+		# around. This is to hopefully prevent bash from
+		# reloading the script immediately, which would likely
+		# fail.
+		TMP=$(mktemp)
+		OUTPUT=$(wget -O "$TMP" https://raw.githubusercontent.com/IDPLAT/rax-docs/master/rax-docs 2>&1) || {
+		    echo "Oops, downloading the latest version failed. Try again later!"
+		    echo ""
+		    echo "$OUTPUT"
+		    echo ""
+		    return 0
+		}
+		chmod --reference=rax-docs "$TMP"
+		mv rax-docs "$TMP.old"
+		mv "$TMP" rax-docs
+		echo ""
+		echo "Thanks for updating! Don't forget to commit the new script!"
+	    fi
 	    echo ""
 	fi
     fi

--- a/tests/fixtures/wrapper-script/wget
+++ b/tests/fixtures/wrapper-script/wget
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# Stubs out wget for tests. We use this to verify the wrapper script
+# auto-update behavior without actually downloading a new version of
+# the script, which would interfere with the tests.
+echo "$@" >> wget-input
+
+# When called, it's told to put the wrapper script into a temp file.
+# To keep tests happy, just copy the current script into that file.
+[ "$1" = -O ] || {
+    echo "Test fixture out of date with script."
+    echo "Expected first option to be the output file."
+    exit 1
+}
+TEMPFILE="$2"
+cp rax-docs "$TEMPFILE"


### PR DESCRIPTION
Since the repo is public, the wrapper script can easily download new
versions of itself on demand. This makes the update prompt the user to
do so, easing the upgrade path.

Closes #23