### PR TITLE
update toolkit and jenkins build to python 3

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -368,10 +368,10 @@ function setup_jenkins {
     echo "Setting up Jenkins build environment"
     echo ""
     # shellcheck disable=SC1091
-    source /opt/rh/python27/enable || fail "Couldn't enable RHSCL Python 2.7"
-    virtualenv jenkinspy2 || fail "Couldn't create the venv to contain this build"
+    source /opt/rh/python33/enable || fail "Couldn't enable RHSCL Python 2.7"
+    virtualenv jenkinspy || fail "Couldn't create the venv to contain this build"
     # shellcheck disable=SC1091
-    source jenkinspy2/bin/activate || fail "Couldn't activate the new venv"
+    source jenkinspy/bin/activate || fail "Couldn't activate the new venv"
     python -V
     # This is the latest version of pip that still works with python 2.7. Can't go any further until this moves to 3.
     pip install --upgrade pip\<21 || fail "Couldn't upgrade pip to latest version"
@@ -428,9 +428,9 @@ function docker_make {
 # pipeline stage starts with a fresh environment.
 function activate_jenkins_env {
     # shellcheck disable=SC1091
-    source /opt/rh/python27/enable || fail "Couldn't enable RHSCL Python 2.7"
+    source /opt/rh/python33/enable || fail "Couldn't enable RHSCL Python 2.7"
     # shellcheck disable=SC1091
-    source jenkinspy2/bin/activate || fail "Couldn't activate the venv"
+    source jenkinspy/bin/activate || fail "Couldn't activate the venv"
     PATH="$(pwd)/docs/bin:$PATH"
     export PATH
 }

--- a/it/docker-image.bats
+++ b/it/docker-image.bats
@@ -41,7 +41,7 @@ function teardown {
 @test "the image has python installed" {
     run docker run --rm rax-docs python --version
     # This is the python version matching Jenkins
-    [ "$output" = "Python 2.7.13" ]
+    [ "$output" = "Python 3.3.6" ]
 }
 
 @test "the image has a pip that works with python 2" {

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.13
+FROM python:3.3.6
 
 COPY requirements.txt requirements.txt
 

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -4,35 +4,35 @@
 
 -i https://pypi.python.org/simple
 alabaster==0.7.12
-babel==2.6.0
+babel==2.5.3
 certifi==2018.10.15
 chardet==3.0.4
 chios==0.1.4
-click==7.0
+click==6.7
 colorclass==2.2.0
 commonmark==0.5.4
 doc8==0.8.0
 docutils==0.14
 filelock==3.0.9
-idna==2.7
-imagesize==1.1.0
+idna==2.6
+imagesize==1.0.0
 jinja2==2.10
-markdown==3.0.1
-markupsafe==1.1.1
-packaging==18.0
+markdown==2.6.11
+markupsafe==1.0
+packaging==16.8
 pandoc==1.0.2
 pbr==5.1.0
 # Can't go to 21 or later until we move to Python 3
 pip<21
-pluggy==0.8.0
+pluggy==0.5.2
 ply==3.11
-py==1.7.0
+py==1.4.34
 pyenchant==2.0.0
 pygments==2.2.0
 pyparsing==2.2.2
 pytz==2018.7
 recommonmark==0.4.0
-requests==2.20.0
+requests==2.18.4
 restructuredtext-lint==1.1.3
 six==1.11.0
 snowballstemmer==1.2.1
@@ -40,8 +40,8 @@ sphinx-rtd-theme==0.4.2
 sphinx==1.5.6
 sphinxcontrib-spelling==4.2.0
 sphinxcontrib-versioning==2.2.1
-sphinxcontrib-websupport==1.1.0
+sphinxcontrib-websupport==1.0.1
 stevedore==1.30.0
 toml==0.10.0
-urllib3==1.24
+urllib3==1.22
 virtualenv==16.0.0


### PR DESCRIPTION
Something just changed on the server hosting files.pythonhosted.org,
where pip seems to be downloading packages from. It's using SNI and/or
SAN differently, and our current python 2 isn't handling it
properly. It looks like we're upgrading to python 3 now.