### PR TITLE
free us from jenkins pythons

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -1,5 +1,18 @@
 #!/bin/bash -e
 
+## The version of Python we're building with in Jenkins. Changing this will cause a new Python
+## to be installed on Jenkins using pyenv. Cleanup is left as a manual task.
+## It's highly recommended that this version stay in sync with the version that the Dockerfile
+## is based on so that devs and Jenkins build the same way.
+PYVERSION=3.6.13
+export PYVERSION
+
+## Where pyenv lives on Jenkins. The home partition is 42G, so it should be a fine place to
+## keep things. I changed from the default of "$HOME/.pyenv" just to make it explicit what's
+## using this pyenv home.
+PYENV_ROOT="$HOME/.pyenv-rax-docs"
+export PYENV_ROOT
+
 ## Delay output a bit to make it feel more comfortable for a human. Setting SPEED=true will disable
 ## the delay so tests will run quickly.
 function pause {
@@ -367,17 +380,59 @@ function setup {
 function setup_jenkins {
     echo "Setting up Jenkins build environment"
     echo ""
-    # shellcheck disable=SC1091
-    source /opt/rh/python27/enable || fail "Couldn't enable RHSCL Python 2.7"
-    virtualenv jenkinspy2 || fail "Couldn't create the venv to contain this build"
-    # shellcheck disable=SC1091
-    source jenkinspy2/bin/activate || fail "Couldn't activate the new venv"
-    python -V
-    # This is the latest version of pip that still works with python 2.7. Can't go any further until this moves to 3.
-    pip install --upgrade pip\<21 || fail "Couldn't upgrade pip to latest version"
-    pip install -r requirements.txt || fail "Couldn't install requirements"
-    echo ""
+    # One-time install of pyenv. It installs to Jenkins home dir, so it can be a shared resource.
+    [ -d "$PYENV_ROOT" ] || {
+        mkdir -p "$PYENV_ROOT"
+        curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
+        mkdir -p "$PYENV_ROOT/rax-docs-installed"
+    }
+    export PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)" || fail "Installing pyenv seems to have failed. Investigate Jenkins."
 
+    # Python install. We signal to ourselves that an install is done by touching a file. If
+    # the install dir exists but the done file doesn't, we need to wait to see if someone
+    # else is building it at the same time. This is the cost of sharing installations. The
+    # time saved is worth it.
+
+    INSTALL_FILE="$PYENV_ROOT/rax-docs-installed/$PYVERSION"
+    if [ ! -d "$PYENV_ROOT/versions/$PYVERSION" ]; then
+        # Eagerly create the dir to minimize race conditions on this directory test
+        mkdir -p "$PYENV_ROOT/versions/$PYVERSION"
+        SPACE_LEFT=$(df -k --output=avail . | tail -1)
+        [ "$SPACE_LEFT" -gt $((500*1024)) ] || {
+            rmdir "$PYENV_ROOT/versions/$PYVERSION"
+            echo "Less than 500MB remaining in Jenkins home partition."
+            echo "Clean up some space before installing more Pythons."
+            exit 1
+        }
+        # Flags suggested for installing 3.4.3 on CentOS 6 to get past SSL errors
+        export CFLAGS=-I/usr/include/openssl
+        export LDFLAGS=-L/usr/lib64
+        time pyenv install -v "$PYVERSION" && touch "$INSTALL_FILE"
+        du -h --max-depth 1 "$PYENV_ROOT/versions"
+    elif [ -d "$PYENV_ROOT/versions/$PYVERSION" ] && ! [ -f "$INSTALL_FILE" ]; then
+        echo "Python $PYVERSION installation directory exists, but the installation"
+        echo "doesn't seem to have finished. That could mean someone else is"
+        echo "running a build that's building this Python now. To avoid conflicts,"
+        echo "this build will now abort. Try again in a few minutes. If the problem"
+        echo "persists, try deleting $PYENV_ROOT/versions/$PYVERSION and running again."
+        exit 1
+    fi
+
+    [ -f "$INSTALL_FILE" ] || \
+	fail "Something went wrong with installing Python $PYVERSION. Investigate Jenkins."
+
+    pyenv local "$PYVERSION"
+
+    # Create a venv because different versions of the toolkit might have different
+    # requirements.
+    python -m venv rax-docs-venv
+    # shellcheck disable=SC1091
+    source rax-docs-venv/bin/activate
+    pip install --upgrade pip
+    pip install -r requirements.txt
+
+    echo ""
     echo "Install vale style checker"
     # We don't have privileges outside the Jenkins workspace, so we just install the vale script to docs/bin
     # and the styles to docs/styles. They'll be reinstalled for every new build.
@@ -427,10 +482,11 @@ function docker_make {
 # is useful when a new stage of the build needs to use some of the installed tools because each
 # pipeline stage starts with a fresh environment.
 function activate_jenkins_env {
+    PATH="$PYENV_ROOT/bin:$PATH"
+    pyenv local "$PYVERSION" || fail "Couldn't activate Python $PYVERSION"
+    eval "$(pyenv init -)" || fail "Couldn't init pyenv"
     # shellcheck disable=SC1091
-    source /opt/rh/python27/enable || fail "Couldn't enable RHSCL Python 2.7"
-    # shellcheck disable=SC1091
-    source jenkinspy2/bin/activate || fail "Couldn't activate the venv"
+    source rax-docs-venv/bin/activate || fail "Couldn't activate the venv"
     PATH="$(pwd)/docs/bin:$PATH"
     export PATH
 }

--- a/it/docker-image.bats
+++ b/it/docker-image.bats
@@ -41,7 +41,7 @@ function teardown {
 @test "the image has python installed" {
     run docker run --rm rax-docs python --version
     # This is the python version matching Jenkins
-    [ "$output" = "Python 2.7.13" ]
+    [ "$output" = "Python 3.6.13" ]
 }
 
 @test "the image has a pip that works with python 2" {

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.13
+FROM python:3.6.13
 
 COPY requirements.txt requirements.txt
 

--- a/tests/project-structure.bats
+++ b/tests/project-structure.bats
@@ -53,3 +53,9 @@
 	[ -f "$BATS_TEST_DIRNAME/$NAME.bats" ]
     done
 }
+
+@test "Docker and Jenkins Python versions match" {
+    FROM_LINE=$(head -1 resources/Dockerfile)
+    VERSION=$(echo "$FROM_LINE" | cut -d : -f 2)
+    grep "^PYVERSION=$VERSION\$" internal/main
+}


### PR DESCRIPTION
The Jenkins that builds docs has only python 2.7 and 3.3 on it. Both
are now too old to work reliably. While trying to find someone to do
some upgrades, I also looked into managing our own python versions and
came up with pyenv. Some experimentation showed that we can
successfully build some python versions on Jenkins, which is running
CentOS 6.9. I don't know how high we can go, but this at least
establishes the precedent and gets us to a supported version of
python.