### PR TITLE
make htmlvers command available

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -682,7 +682,7 @@ TOPCMD="$1"
 shift
 
 case $TOPCMD in
-    internal_install|status|usage|setup|html|testy|post_build_preview)
+    internal_install|status|usage|setup|html|htmlvers|testy|post_build_preview)
 	$TOPCMD "$@"
 	;;
 

--- a/tests/main-build-tools.bats
+++ b/tests/main-build-tools.bats
@@ -65,3 +65,30 @@ function teardown {
     [ "$(head -1 docker-input)" = "rmi rax-docs:latest" ]
     [ "$(tail -1 docker-input)" = "build .rax-docs/repo/resources -t rax-docs" ]
 }
+
+@test "'test' runs tests in docker via make" {
+    run ./rax-docs test
+    [ "$status" -eq 0 ]
+    # First, a check to ensure the dev environment is set up
+    [ "$(head -1 docker-input)" = "image inspect rax-docs" ]
+    # Then, html runs through docker using the makefile
+    [[ "$(tail -1 docker-input)" =~ ^run\ .*\ rax-docs\ make\ .*\ test$ ]]
+}
+
+@test "'html' builds html in docker via make" {
+    run ./rax-docs html
+    [ "$status" -eq 0 ]
+    # First, a check to ensure the dev environment is set up
+    [ "$(head -1 docker-input)" = "image inspect rax-docs" ]
+    # Then, html runs through docker using the makefile
+    [[ "$(tail -1 docker-input)" =~ ^run\ .*\ rax-docs\ make\ .*\ html$ ]]
+}
+
+@test "'htmlvers' builds versioned html in docker via make" {
+    run ./rax-docs htmlvers
+    [ "$status" -eq 0 ]
+    # First, a check to ensure the dev environment is set up
+    [ "$(head -1 docker-input)" = "image inspect rax-docs" ]
+    # Then, html runs through docker using the makefile
+    [[ "$(tail -1 docker-input)" =~ ^run\ .*\ rax-docs\ make\ .*\ htmlvers$ ]]
+}


### PR DESCRIPTION
This command, which generates versioned docs based on existing remote
branches, was added internally but not made available to users
before. This "exports" the command and adds basic tests for the main
building commands.

Closes #31