### PR TITLE
jenkins should build docs before publishing

### DIFF
--- a/resources/Jenkinsfile
+++ b/resources/Jenkinsfile
@@ -52,6 +52,7 @@ node {
 	}
     } else {
         stage("Release stuff") {
+            sh './rax-docs htmlvers'
             sh './rax-docs publish'
         }
     }


### PR DESCRIPTION
The pipeline stage that publishes docs on merging a PR tries to
publish without building the docs. You have to have docs built locally
before publishing.