### PR TITLE
don't nuke existing gitignore

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -296,10 +296,10 @@ function install_go {
     }
     IGNORE="# Ignore rax-docs installation. It should be pulled with './rax-docs get' when needed.\n.rax-docs/repo\n"
     IGNORE+="# Ignore rax-docs cache dir, where info specific to the local installation is stored.\n.rax-docs/cache"
-    if [ -f .gitignore ] && ! grep '^.rax-docs/repo' .gitignore > /dev/null; then
-	echo -e "\n$IGNORE" >> .gitignore
-    else
+    if ! [ -f .gitignore ]; then
 	echo -e "$IGNORE" > .gitignore
+    elif ! grep '^.rax-docs/repo' .gitignore > /dev/null; then
+	echo -e "\n$IGNORE" >> .gitignore
     fi
     install_all_done
 }

--- a/tests/main-install.bats
+++ b/tests/main-install.bats
@@ -234,6 +234,16 @@ Clone url : git url"
     # Then the gitignores shouldn't be duplicated
     COUNT=$(grep -c '^.rax-docs/' .gitignore)
     [ "$COUNT" = 2 ]
+    # When the gitignore has other entries in it
+    echo "more entries" >> .gitignore
+    # And I install again
+    run .rax-docs/repo/internal/main internal_install <<<"$ALL_YES"
+    [ "$status" -eq 0 ]
+    # Then the entries still aren't duplicated
+    COUNT=$(grep -c '^.rax-docs/' .gitignore)
+    [ "$COUNT" = 2 ]
+    # And the new entry is still there
+    grep '^more entries$' .gitignore
 }
 
 @test "installing over an installation succeeds" {


### PR DESCRIPTION
The last change around gitignore introduced a bug where it would
replace your gitignore with one containing only the rax-docs
ignores. This fixes it with an updated test to catch the issue.