### PR TITLE
restore "install latest" to original behavior

### DIFF
--- a/rax-docs
+++ b/rax-docs
@@ -36,11 +36,10 @@ function install {
         echo "$OUTPUT"
         exit 1
     }
-    VERSION="${1:-master}"
-    OUTPUT=$(git -C .rax-docs/repo checkout "$VERSION" 2>&1) || {
+    [ -z "$1" ] || OUTPUT=$(git -C .rax-docs/repo checkout "$1" 2>&1) || {
 	echo "Error checking out requested version."
 	echo ""
-	echo "The version you requested ($VERSION) isn't a valid git treeish."
+	echo "The version you requested ($1) isn't a valid git treeish."
 	echo "You need to specify a tag, branch, or commit hash to install."
 	echo ""
 	echo "$OUTPUT"

--- a/tests/wrapper-script.bats
+++ b/tests/wrapper-script.bats
@@ -57,6 +57,14 @@ function teardown {
     [ "$(cat main-input)" = "internal_install some-version" ]
 }
 
+@test "installing with no version doesn't try to check out because it means latest" {
+    run ./rax-docs install <<<"$(printf "y\ny\ny\ny\ny\ny\ny\n")"
+    [ "${lines[-1]}" = "install command completed" ]
+    [ $status -eq 0 ]
+    [ "$(cat git-input)" = "clone https://github.com/IDPLAT/rax-docs.git .rax-docs/repo" ]
+    [ "$(cat main-input)" = "internal_install" ]
+}
+
 @test "install passes all args to internal script" {
     run ./rax-docs install foo bar baz abc xyz <<<"$(printf "y\ny\ny\ny\ny\ny\ny\n")"
     [ "$(cat main-input)" = "internal_install foo bar baz abc xyz" ]


### PR DESCRIPTION
I recently realized that the wrapper needs to check out the right
toolkit version during install so that it's running the correct
version of the internal scripts at install time. I added the "default
to master" checkout at that time, but it's more correct to just clone
without checking out and defer to the "install latest" logic in the
internal script.