### PR TITLE
update "old files" signature

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -205,8 +205,8 @@ function install_check_old_files {
     SIGNATURE_FILES=(
 	Jenkinsfile
 	Makefile
+	requirements.txt
 	docs/Makefile
-	tox.ini
     )
     SIGNATURE_MATCH=true
     for F in "${SIGNATURE_FILES[@]}"; do

--- a/tests/main-install.bats
+++ b/tests/main-install.bats
@@ -263,7 +263,7 @@ Clone url : git url"
     [ "$status" -eq 0 ]
     # The legacy tools should be removed.
     [ ! -f Makefile ]
-    [ ! -f tox.ini ]
+    [ ! -f requirements.txt ]
     [ ! -d scripts ]
     [ ! -f test.sh ]
     [ ! -f Pipfile ]
@@ -279,8 +279,8 @@ function make_starter_kit_files {
     # key commands. See the script for specifics.
     touch Makefile
     mkdir docs
+    touch requirements.txt
     touch docs/Makefile
-    touch tox.ini
     echo "source /opt/rh/rh-git29/enable" > Jenkinsfile
     mkdir scripts
     echo "source jenkinspy2/bin/activate" > scripts/build.sh


### PR DESCRIPTION
The logic that determines if legacy toolkit files need to be cleaned
up was looking for a tox.ini, which I've already removed from a couple
of more modern docs projects. Look for the requirements.txt instead.