### PR TITLE
jenkins uses the rax-docs requirements.txt

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -430,7 +430,7 @@ function setup_jenkins {
     # shellcheck disable=SC1091
     source rax-docs-venv/bin/activate
     pip install --upgrade pip
-    pip install -r requirements.txt
+    pip install -r .rax-docs/repo/resources/requirements.txt
 
     echo ""
     echo "Install vale style checker"


### PR DESCRIPTION
Due to a few minor oversights, the setup_jenkins function that gets
the build env ready on jenkins was using a project-local
requirements.txt. This was left over in the docs project I tested the
function out with because the "old files cleanup" wasn't running on it
properly. This switches jenkins to use the toolkit's requirements.txt
instead.