### PR TITLE
fix NPE in jenkins master builds

### DIFF
--- a/resources/Jenkinsfile
+++ b/resources/Jenkinsfile
@@ -20,7 +20,7 @@ node {
     /**
      * True if this is a PR build.
      */
-    def isPr = !env.CHANGE_BRANCH.isEmpty()
+    def isPr = !env.CHANGE_BRANCH?.isEmpty()
 
     stage ('Gather intel') {
         sh 'lsb_release -a'


### PR DESCRIPTION
Everything has worked fine in PR's, but when we merged, the master
build failed because CHANGE_BRANCH is unset, not just empty. We need
to account for a null value there.