### PR TITLE
fix isPR variable

### DIFF
--- a/resources/Jenkinsfile
+++ b/resources/Jenkinsfile
@@ -20,7 +20,7 @@ node {
     /**
      * True if this is a PR build.
      */
-    def isPr = !env.CHANGE_BRANCH?.isEmpty()
+    def isPr = env.CHANGE_BRANCH != null
 
     stage ('Gather intel') {
         sh 'lsb_release -a'


### PR DESCRIPTION
The `isPR` variable wasn't being evaluated correctly, and was returning
`true` when the string was `null` due to it being a master and not a
change branch. Checking to see if the string isn't null is sufficient to
determine if what is being built is a PR.