### PR TITLE
use remote ref for gh-pages in publish

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -574,7 +574,7 @@ function publish {
     else
 	MESSAGE="Manually published by $USER"
     fi
-    git worktree add dragons gh-pages || fail "Failed to add worktree for publishing to gh-pages"
+    git worktree add dragons origin/gh-pages || fail "Failed to add worktree for publishing to gh-pages"
     rm -rf dragons/*
     rsync -a docs/_build/html/ dragons/
     cd dragons || fail "Failed to switch to worktree dir for publishing"


### PR DESCRIPTION
Depending on how jenkins clones the project, all the refs may or may
not be transferred. Remote refs are more likely to be available.