### PR TITLE
action to require labels on PRs

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,15 @@
+name: LabelCheck
+
+on:
+  pull_request_target:
+    types: [ opened, labeled, unlabeled, synchronize ]
+
+jobs:
+  PR-label-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+      with:
+        github-token: '${{ secrets.GITHUB_TOKEN }}'
+        valid-labels: 'feature, fix, test, internal'
+        pull-request-number: '${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Since the changelog and release notes are built based on labels, and
no label means a PR doesn't show up, we need to encourage label
use. This requires one of the labels recognized by the changelog
action, or "internal", which I hope will serve to mark a PR as
something that doesn't need to be in the release notes.