### PR TITLE
Update the vale install

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -13,6 +13,12 @@ export PYVERSION
 PYENV_ROOT="$HOME/.pyenv-rax-docs"
 export PYENV_ROOT
 
+## The version of vale we're going to install and use. Changing this will download a new version
+## of vale and extract it into /usr/local/lib. The install task will symlink the newer version to
+## /usr/local/bin, but it will not clean up the old version left in the the lib dir.
+VALE_VERSION=2.4.0
+export VALE_VERSION
+
 ## Delay output a bit to make it feel more comfortable for a human. Setting SPEED=true will disable
 ## the delay so tests will run quickly.
 function pause {
@@ -436,8 +442,10 @@ function setup_jenkins {
     echo "Install vale style checker"
     # We don't have privileges outside the Jenkins workspace, so we just install the vale script to docs/bin
     # and the styles to docs/styles. They'll be reinstalled for every new build.
-    wget https://install.goreleaser.com/github.com/ValeLint/vale.sh || fail "Couldn't download Vale script"
-    sh vale.sh -b docs/bin v2.4.0 || fail "Couldn't run Vale installer"
+    wget https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz || fail "Couldn't download Vale script"
+    mkdir /usr/local/lib/vale-${VALE_VERSION} || fail "Couldn't make the vale lib dir"
+    tar -xvzf vale_${VALE_VERSION}_Linux_64-bit.tar.gz -C /usr/local/lib/vale-${VALE_VERSION} || fail "Couldn't untar vale"
+    ln -s /usr/local/lib/vale-${VALE_VERSION}/vale /usr/local/bin/vale || fail "Couldn't link the vale executable to /usr/local/bin"
     mkdir -p docs/styles/Vocab
     git clone https://github.com/achatur/docs-vale.git docs/styles/docs-vale || fail "Couldn't get local styles"
     git clone https://github.com/errata-ai/Google.git docs/styles/Google || fail "Couldn't get Google styles"

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -28,8 +28,12 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --upgrade pip\<21
 RUN pip install -r requirements.txt
 
-run wget https://install.goreleaser.com/github.com/ValeLint/vale.sh && \
-    sh vale.sh -b /usr/local/bin v2.4.0 && \
+ARG VALE_VERSION=2.4.0
+
+run wget https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz && \
+    mkdir /usr/local/lib/vale-${VALE_VERSION} && \
+    tar -xvzf vale_${VALE_VERSION}_Linux_64-bit.tar.gz -C /usr/local/lib/vale-${VALE_VERSION} && \
+    ln -s /usr/local/lib/vale-${VALE_VERSION}/vale /usr/local/bin/vale && \
     mkdir -p styles/Vocab && \
     git clone https://github.com/achatur/docs-vale.git styles/docs-vale && \
     git clone https://github.com/errata-ai/Google.git styles/Google && \


### PR DESCRIPTION
The old way to install vale via the vail.sh script has been deprecated.
The PR updates the install for both the docker image and the script
which runs inside of Jenkins.
