### PR TITLE
Move the vale install dir on Jenkins

### DIFF
--- a/internal/main
+++ b/internal/main
@@ -443,10 +443,10 @@ function setup_jenkins {
     # We don't have privileges outside the Jenkins workspace, so we just install the vale script to docs/bin
     # and the styles to docs/styles. They'll be reinstalled for every new build.
     wget https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz || fail "Couldn't download Vale script"
-    mkdir /usr/local/lib/vale-${VALE_VERSION} || fail "Couldn't make the vale lib dir"
-    tar -xvzf vale_${VALE_VERSION}_Linux_64-bit.tar.gz -C /usr/local/lib/vale-${VALE_VERSION} || fail "Couldn't untar vale"
-    ln -s /usr/local/lib/vale-${VALE_VERSION}/vale /usr/local/bin/vale || fail "Couldn't link the vale executable to /usr/local/bin"
-    mkdir -p docs/styles/Vocab
+    mkdir docs/lib/vale-${VALE_VERSION} || fail "Couldn't make the vale lib dir"
+    tar -xvzf vale_${VALE_VERSION}_Linux_64-bit.tar.gz -C docs/lib/vale-${VALE_VERSION} || fail "Couldn't untar vale to docs/lib"
+    ln -s docs/lib/vale-${VALE_VERSION}/vale docs/bin/vale || fail "Couldn't link the vale executable to docs/bin"
+    mkdir -p docs/styles/Vocab || fail "Couldn't make the docs/styles/Vocab dir"
     git clone https://github.com/achatur/docs-vale.git docs/styles/docs-vale || fail "Couldn't get local styles"
     git clone https://github.com/errata-ai/Google.git docs/styles/Google || fail "Couldn't get Google styles"
     git clone https://github.com/errata-ai/Microsoft.git docs/styles/Microsoft || fail "Couldn't get MS styles"


### PR DESCRIPTION
The build script doesn't have access to `/usr/local/lib` or
`/usr/local/bin` so vale could not be extracted or linked to those
locations. It does have access to the `docs` directory within the
workspace, so I've updated the script to drop everything in there.
